### PR TITLE
Update diabetologie.qmd

### DIFF
--- a/diabetologie.qmd
+++ b/diabetologie.qmd
@@ -15,15 +15,10 @@ Künstliche Intelligenz (KI) wird in der Diabetologie in mehreren Bereichen eing
 | Software        | Anbieter                          | URL                                          | Anmerkungen                                                                                     |
 |----------------|----------------------------------|----------------------------------------------|------------------------------------------------------------------------------------------------|
 | **mySugr**     | Roche Diabetes Care             | [mysugr.com](https://mysugr.com)            | Diabetes-Tagebuch mit Blutzucker-Tracking und Berichten                                         |
-| **Glucose Buddy** | Azumio                        | [Healthline](https://www.healthline.com/health/diabetes/top-iphone-android-apps) | Synchronisation mit CGM-Systemen, Blutzuckerprotokoll                                          |
-| **Diabetes:M** | Sirma Medical Systems           | [diabetes-m.com](https://diabetes-m.com/)   | Detaillierte Analyse, Bolusrechner, Berichte                                                   |
-| **Fooducate**  | Fooducate Ltd.                  | [Fooducate](https://www.healthline.com/health/diabetes/top-iphone-android-apps) | Barcode-Scanner zur Ernährungsanalyse                                                          |
-| **BlueLoop**   | Children with Diabetes         | [chop.edu](https://www.chop.edu/health-resources/diabetes-apps) | Diabetes-Management speziell für Kinder                                                        |
-| **Dexcom G7 App** | Dexcom Inc.                  | [adces.org](https://www.adces.org/education/danatech/apps-dtx/find-apps-tools) | Echtzeit-Blutzuckerwerte mit CGM-System                                                        |
+| **Glucose Buddy** | Azumio                        | [Healthline](https://www.glucosebuddy.com/) | Synchronisation mit CGM-Systemen, Blutzuckerprotokoll                                          |
+| **Diabetes:M** | Sirma Medical Systems           | [diabetes-m.com](https://diabetes-m.com/)   | Detaillierte Analyse, Bolusrechner, Berichte                                                                                                          |
+| **BlueLoop**   | Children with Diabetes         | [chop.edu](https://blueloop.mycareconnect.com/) | Diabetes-Management speziell für Kinder                                                        |
 | **DiabTrend**  | DiabTrend Ltd.                  | [diabtrend.com](https://diabtrend.com/)     | KI-gestützte Blutzuckerprognose, Tagebuch, Rezept-Datenbank                                    |
-| **One Drop**   | One Drop                        | [Clemson Univ.](https://hgic.clemson.edu/factsheet/smartphone-apps-for-diabetes-self-management-support/) | Tracking von Blutzucker, Medikamenten und Aktivität                                           |
-| **Dario Health** | LabStyle Innovations         | [Clemson Univ.](https://hgic.clemson.edu/factsheet/smartphone-apps-for-diabetes-self-management-support/) | Blutzuckermessungen mit direkter Smartphone-Übertragung                                       |
-| **CalorieKing** | CalorieKing Wellness Solutions | [DiabetesEd](https://diabetesed.net/apps-for-diabetes/) | Große Lebensmitteldatenbank für Kohlenhydratzählung                                           |
 
 : Apps für Patient:innen (D2C)
 


### PR DESCRIPTION
URL von Glucose buddy und Blueloop falsch, Dexcom haben die Pat auftomatisch, wenn sie das Device im Arm haben. Fooducate, Onedrop, Dario, Calorieking Apps nicht spezifisch, dann würde ich lieber ähnliche Apps in deutscher Sprache einfügen.